### PR TITLE
feat: Ping now checks that portal is fully healthy

### DIFF
--- a/daemon/client/port_forwarding/chisel/port_forward_session_factory.go
+++ b/daemon/client/port_forwarding/chisel/port_forward_session_factory.go
@@ -169,6 +169,13 @@ func (factory *PortForwardSessionFactory) GetSessions() map[uuid.UUID]port_forwa
 	return factory.currentSessions
 }
 
+func (factory *PortForwardSessionFactory) IsHealthy(ctx context.Context) error {
+	if _, err := factory.portalServerClient.Ping(ctx, portal_constructors.NewPortalPing()); err != nil {
+		return stacktrace.Propagate(err, "Unable to communicate with Portal Server.")
+	}
+	return nil
+}
+
 func (factory *PortForwardSessionFactory) getSimilarExistingSessionsIfAny(params *port_forwarding.PortForwardingParams) (bool, uuid.UUID) {
 	for sessionUuid, otherSession := range factory.currentSessions {
 		if otherSession.GetParams().Equals(params) {

--- a/daemon/client/port_forwarding/port_forwarding_session_factory.go
+++ b/daemon/client/port_forwarding/port_forwarding_session_factory.go
@@ -1,9 +1,14 @@
 package port_forwarding
 
-import "github.com/google/uuid"
+import (
+	"context"
+	"github.com/google/uuid"
+)
 
 type PortForwardingSessionFactory interface {
 	NewSession(params *PortForwardingParams) (PortForwardingSession, error)
 
 	GetSessions() map[uuid.UUID]PortForwardingSession
+
+	IsHealthy(ctx context.Context) error
 }

--- a/daemon/client/portal_client.go
+++ b/daemon/client/portal_client.go
@@ -42,7 +42,6 @@ func (portalClient *KurtosisPortalClient) Ping(ctx context.Context, ping *portal
 		return nil, stacktrace.Propagate(err, "Portal client is running but connection with remote is unhealthy")
 	}
 	return portal_constructors.NewPortalPong(), nil
-
 }
 
 func (portalClient *KurtosisPortalClient) SwitchContext(_ context.Context, _ *portal_api.SwitchContextArgs) (*portal_api.SwitchContextResponse, error) {

--- a/daemon/client/portal_client.go
+++ b/daemon/client/portal_client.go
@@ -35,6 +35,12 @@ func NewKurtosisClient() *KurtosisPortalClient {
 }
 
 func (portalClient *KurtosisPortalClient) Ping(ctx context.Context, ping *portal_api.PortalPing) (*portal_api.PortalPong, error) {
+	if portalClient.factory == nil {
+		return portal_constructors.NewPortalPong(), nil
+	}
+	if err := portalClient.factory.IsHealthy(ctx); err != nil {
+		return nil, stacktrace.Propagate(err, "Portal client is running but connection with remote is unhealthy")
+	}
 	return portal_constructors.NewPortalPong(), nil
 
 }

--- a/kurtosis/portal_launcher/portal_launcher.star
+++ b/kurtosis/portal_launcher/portal_launcher.star
@@ -1,5 +1,5 @@
-PORTAL_SERVICE_SUFFIX = "_service"
-PORTAL_PROXY_SUFFIX = "_proxy"
+PORTAL_SERVICE_SUFFIX = "-service"
+PORTAL_PROXY_SUFFIX = "-proxy"
 
 # Portal server constants
 SERVER_GRPC_PORT_ID = "server_grpc"


### PR DESCRIPTION
It used to check only for the client. Now it throws an error if the client is not able to communicate with the server