### PR TITLE
fix: Unlimited reconnect retries for ports to forward

### DIFF
--- a/daemon/client/port_forwarding/chisel/port_forward_session_factory.go
+++ b/daemon/client/port_forwarding/chisel/port_forward_session_factory.go
@@ -36,6 +36,10 @@ const (
 	certFileName       = "cert.pem"
 	keyFileName        = "key.pem"
 	tlsFilesPerm       = 0644
+
+	chiselClientConfigKeepAlive        = 25 * time.Second
+	chiselClientConfigMaxRetry         = -1 // unlimited retries
+	chiselClientConfigMaxRetryInterval = 10 * time.Second
 )
 
 type PortForwardSessionFactory struct {
@@ -77,7 +81,7 @@ func NewPortForwardSessionFactory(portalHost string, portalGrpcPort uint32, port
 		chiselPort:         portalChiselPort,
 		currentSessions:    map[uuid.UUID]port_forwarding.PortForwardingSession{},
 		portalServerClient: serverClient,
-		remote_endpoints:          remoteEndpoints,
+		remote_endpoints:   remoteEndpoints,
 	}, nil
 }
 
@@ -97,7 +101,7 @@ func NewPortForwardSessionFactoryForLocalContext() (*PortForwardSessionFactory, 
 		chiselPort:         server.PortalServerTunnelPort,
 		currentSessions:    map[uuid.UUID]port_forwarding.PortForwardingSession{},
 		portalServerClient: serverClient,
-		remote_endpoints:          map[portal_api.RemoteEndpointType]string{},
+		remote_endpoints:   map[portal_api.RemoteEndpointType]string{},
 	}, nil
 }
 
@@ -145,9 +149,9 @@ func (factory *PortForwardSessionFactory) NewSession(params *port_forwarding.Por
 	chiselClientConfig := &chclient.Config{
 		Fingerprint:      "",
 		Auth:             "",
-		KeepAlive:        25 * time.Second,
-		MaxRetryCount:    5,
-		MaxRetryInterval: 1 * time.Second,
+		KeepAlive:        chiselClientConfigKeepAlive,
+		MaxRetryCount:    chiselClientConfigMaxRetry,
+		MaxRetryInterval: chiselClientConfigMaxRetryInterval,
 		Server:           serverUrl,
 		Proxy:            "",
 		Remotes: []string{
@@ -162,7 +166,7 @@ func (factory *PortForwardSessionFactory) NewSession(params *port_forwarding.Por
 			ServerName: serverName,
 		},
 		DialContext: nil,
-		Verbose:     false,
+		Verbose:     true,
 	}
 
 	chiselClient, err := chclient.NewClient(chiselClientConfig)


### PR DESCRIPTION
The current port forward connection loop tries to reconnect five times after 100, 200, 400, 800 msec and 1 sec (max retry interval) before giving up.  This means that if the portal server is out of reach for more than ~3 seconds, the connections are lost and the session states are still set to `running`.  The immediate need based on our testing is to be more resilient to network connectivity issues.  This change sets the number of retries to unlimited with a max retry interval of 10 seconds.  This change also enables info logging in the Chisel client.  This change does not break the server API so it only requires an updated Portal client.

More work is required to address the following issues (GitHub issues will be created for those):
- The portal does not know about removed services.  The connection loop will run forever for those service ports.  Port forwarding should be refreshed after a Starlark run.  There needs to be way to clear port forwarding for an enclave and create a new set.  AFAIK the current code creates new connections for new services but does not clean up.
- The portal is stateless so all the connections are lost when it restarts.

Here is the Portal log output when the Portal server goes away for a while and then comes back:

```
2023/08/29 20:02:39 client: Disconnected
2023/08/29 20:02:39 client: Connection error: websocket: close 1006 (abnormal closure): unexpected EOF
2023/08/29 20:02:39 client: Retrying in 100ms...
2023/08/29 20:02:39 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 1/unlimited)
2023/08/29 20:02:39 client: Retrying in 200ms...
2023/08/29 20:02:39 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 2/unlimited)
2023/08/29 20:02:39 client: Retrying in 400ms...
2023/08/29 20:02:39 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 3/unlimited)
2023/08/29 20:02:39 client: Retrying in 800ms...
2023/08/29 20:02:40 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 4/unlimited)
2023/08/29 20:02:40 client: Retrying in 1.6s...
2023/08/29 20:02:42 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 5/unlimited)
2023/08/29 20:02:42 client: Retrying in 3.2s...
2023/08/29 20:02:45 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 6/unlimited)
2023/08/29 20:02:45 client: Retrying in 6.4s...
2023/08/29 20:02:51 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 7/unlimited)
2023/08/29 20:02:51 client: Retrying in 10s...
2023/08/29 20:03:01 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 8/unlimited)
2023/08/29 20:03:01 client: Retrying in 10s...
2023/08/29 20:03:11 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 9/unlimited)
2023/08/29 20:03:11 client: Retrying in 10s...
2023/08/29 20:03:21 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 10/unlimited)
2023/08/29 20:03:21 client: Retrying in 10s...
2023/08/29 20:03:31 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 11/unlimited)
2023/08/29 20:03:31 client: Retrying in 10s...
2023/08/29 20:03:41 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 12/unlimited)
2023/08/29 20:03:41 client: Retrying in 10s...
2023/08/29 20:03:51 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 13/unlimited)
2023/08/29 20:03:51 client: Retrying in 10s...
2023/08/29 20:04:01 client: Connection error: dial tcp 18.214.172.162:9721: connect: connection refused (Attempt: 14/unlimited)
2023/08/29 20:04:01 client: Retrying in 10s...
2023/08/29 20:04:12 client: Connected (Latency 17.696584ms)
```