### PR TITLE
fix: relative paths so that intergration tests can run

### DIFF
--- a/kurtosis/main.star
+++ b/kurtosis/main.star
@@ -1,4 +1,4 @@
-TEST_ROOT_FOLDER = "/integration_tests/"
+TEST_ROOT_FOLDER = "./integration_tests/"
 
 PORTAL_IMAGE="kurtosistech/kurtosis-portal"
 

--- a/kurtosis/portal_launcher/portal_launcher.star
+++ b/kurtosis/portal_launcher/portal_launcher.star
@@ -19,7 +19,7 @@ PORTAL_PROXY_SINGLE_PORT_ID = "proxy"
 
 # MISC constants
 ENVOY_IMAGE_NAME = "envoyproxy/envoy:v1.25-latest"
-RESOURCE_FOLDER = "./portal_launcher/resources/"
+RESOURCE_FOLDER = "./resources/"
 DEFAULT_CONTEXT_ID_AND_NAME = "default"
 
 


### PR DESCRIPTION
Running `./scripts/run-all-kurtosis-tests.s` would yield an error:

```
There was an error interpreting Starlark code
Evaluation error: An error occurred while loading the module 'github.com/kurtosis-tech/kurtosis-portal/integration_tests/client_ping_test.star'
	Caused by: '/integration_tests/client_ping_test.star' doesn't exist in the package 'kurtosis-tech/kurtosis-portal'
	at [github.com/kurtosis-tech/kurtosis-portal/kurtosis/main.star:12:32]: run

Error encountered running Starlark code.
```

This fixes the run.  

What I'm not certain about is whether there are other contexts from which these run that I may have broken.